### PR TITLE
Cap cc at 86 as llvm 15 is required for 89+ and this predates the llvm 15 patch

### DIFF
--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -462,6 +462,11 @@ void init_triton_codegen(py::module &&m) {
               size_t major = cuGetInfo<CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR>(dev);
               size_t minor = cuGetInfo<CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR>(dev);
               cc = major*10 + minor;
+
+              // Doesn't support cc > 86
+              if (cc > 86) {
+                cc = 86;
+              }
             }
             int version;
             std::string ptxas_path = drv::path_to_ptxas(version);


### PR DESCRIPTION
pre_mlir doesn't support `sm_89` (perhaps `sm_90` as well but I don't have an H100 to test with). This prevents a computed cc from being > `86` which seems to be the maximum level support by triton at this commit.