### PR TITLE
Triton pre mlir enabled sm90

### DIFF
--- a/include/triton/external/CUDA/cuda.h
+++ b/include/triton/external/CUDA/cuda.h
@@ -1074,7 +1074,8 @@ typedef enum CUjit_target_enum
     CU_TARGET_COMPUTE_72 = 72,       /**< Compute device class 7.2.*/
     CU_TARGET_COMPUTE_75 = 75,       /**< Compute device class 7.5.*/
     CU_TARGET_COMPUTE_80 = 80,       /**< Compute device class 8.0.*/
-    CU_TARGET_COMPUTE_86 = 86        /**< Compute device class 8.6.*/
+    CU_TARGET_COMPUTE_86 = 86,       /**< Compute device class 8.6.*/
+    CU_TARGET_COMPUTE_90 = 90        /**< Compute device class 9.0.*/
 } CUjit_target;
 
 /**

--- a/include/triton/external/CUDA/cuda.h
+++ b/include/triton/external/CUDA/cuda.h
@@ -1075,6 +1075,7 @@ typedef enum CUjit_target_enum
     CU_TARGET_COMPUTE_75 = 75,       /**< Compute device class 7.5.*/
     CU_TARGET_COMPUTE_80 = 80,       /**< Compute device class 8.0.*/
     CU_TARGET_COMPUTE_86 = 86,       /**< Compute device class 8.6.*/
+    CU_TARGET_COMPUTE_89 = 89,       /**< Compute device class 8.9. not tested*/
     CU_TARGET_COMPUTE_90 = 90        /**< Compute device class 9.0.*/
 } CUjit_target;
 

--- a/lib/driver/llvm.cc
+++ b/lib/driver/llvm.cc
@@ -149,7 +149,7 @@ namespace triton
     int vptx(int version)
     {
       if (version >= 11040)
-        return 80;
+        return 78;
       // if(version >= 11030) return 73;
       // if(version >= 11020) return 72;
       // if(version >= 11010) return 71;

--- a/lib/driver/llvm.cc
+++ b/lib/driver/llvm.cc
@@ -149,7 +149,7 @@ namespace triton
     int vptx(int version)
     {
       if (version >= 11040)
-        return 74;
+        return 80;
       // if(version >= 11030) return 73;
       // if(version >= 11020) return 72;
       // if(version >= 11010) return 71;

--- a/lib/driver/llvm.cc
+++ b/lib/driver/llvm.cc
@@ -163,8 +163,8 @@ namespace triton
     std::string llir_to_ptx(llvm::Module *module, int cc, int version)
     {
       // LLVM version in use may not officially support target hardware
-      int max_nvvm_cc = 75;
-      int max_nvvm_ptx = 74;
+      int max_nvvm_cc = 90;
+      int max_nvvm_ptx = 80;
       // options
       auto options = llvm::cl::getRegisteredOptions();
       auto *short_ptr = static_cast<llvm::cl::opt<bool> *>(options["nvptx-short-ptr"]);

--- a/lib/driver/llvm.cc
+++ b/lib/driver/llvm.cc
@@ -148,8 +148,9 @@ namespace triton
 
     int vptx(int version)
     {
-      if (version >= 11040)
-        return 78;
+      if (version >= 12010) return 80;
+      if (version >= 11080) return 78;
+      if (version >= 11040) return 74;
       // if(version >= 11030) return 73;
       // if(version >= 11020) return 72;
       // if(version >= 11010) return 71;

--- a/python/setup.py
+++ b/python/setup.py
@@ -113,7 +113,7 @@ class CMakeBuild(build_ext):
             self.build_extension(ext)
 
     def build_extension(self, ext):
-        triton_cache_path = os.path.join(os.environ["HOME"], ".triton")
+        triton_cache_path = os.path.join(os.environ["HOME"], ".triton_pre_mlir")
         thirdparty_cmake_args = get_thirdparty_packages(triton_cache_path)
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.path)))
         # create build directories


### PR DESCRIPTION
H100 enabled triton_pre_mlir
https://github.com/vchiley/triton/compare/triton_pre_mlir...vchiley:triton:triton_pre_mlir_sm90?expand=1

On a single H100, FLOPS using 1B MPT with torch_crossentropy and microbatchsize=12:

triton: 256_993_451_664_066
triton: 254_201_243_061_146 (with ALiBi enabled)
flash:  227_260_623_999_127 (no ALiBi support)
torch:  117_315_579_905_781 (requires microbatchsize=4)

Note: the resulting MFU numbers are not really good...
Does it run? Yes.
Is it faster than A100s? Yes, about 1.4x faster.
Is it way worse than what we were seeing when we benchmarked it previously? Yes; we [previously](https://www.mosaicml.com/blog/coreweave-nvidia-h100-part-1) saw about 2x faster (with SXM4 H100s).
BUT this is extremely prelim testing with PCIe H100s from Lambda Cloud (SXM4 H100s are faster)

Note: testing on 1x H100 so FSDP is disabled (cpu init)

Issues:
1. with llm-foundry: `loss_fn: fused_crossentropy` does not work; we need to revert back to `loss_fn: torch_crossentropy`
2. the following prints out a bunch of times, but then it runs anyway (note: I think this is a Torch2 + H100 issue):
```
Starting training...
******************************
Config:
enabled_algorithms/GradientClipping: true
node_name: unknown because NODENAME environment variable not set
num_gpus_per_node: 1
num_nodes: 1
rank_zero_seed: 17

******************************
'sm_90' is not a recognized processor for this target (ignoring processor)
'sm_90' is not a recognized processor for this target (ignoring processor)
...
'sm_90' is not a recognized processor for this target (ignoring processor)
'sm_90' is not a recognized processor for this target (ignoring processor)
[batch=1/13400]:
         Train time/epoch: 0
         Train time/batch: 0
         Train time/sample: 0
         Train time/batch_in_epoch: 0
```

tldr: triton is faster than flash, and works with ALiBi